### PR TITLE
Add Security Considerations section adapted from N-Quads.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -95,7 +95,7 @@
 <section id="sec-trig-intro" class="informative">
   <h2>TriG Language</h2>
 
-  <p>A TriG document allows writing down an RDF Dataset in a compact textual form.
+  <p>A <a>TriG document</a> allows writing down an RDF Dataset in a compact textual form.
   It consists of a sequence of directives, triple statements,
   graph statements which contain triple-generating statements and optional blank lines.
   Comments may be given after a <code>#</code> that is not part of another
@@ -135,7 +135,7 @@
     <p>A graph statement pairs an IRI or blank node with a RDF graph.
       The triple statements that make up the graph are enclosed in <code>{}</code>.</p>
 
-    <p>In a TriG document a graph IRI or blank node may be used as label
+    <p>In a <a>TriG document</a> a graph IRI or blank node may be used as label
       for more than one graph statements.
       The graph label of a graph statement may be omitted.
       In this case the graph is considered the default graph of the RDF Dataset.</p>
@@ -238,16 +238,16 @@
 <section id="conformance">
   <p>This specification defines conformance criteria for:</p>
   <ul>
-    <li>TriG documents
-    <li>TriG parsers
+    <li>TriG documents</li>
+    <li>TriG parsers</li>
   </ul>
 
-  <p>A conforming <strong>TriG document</strong> is a Unicode string that conforms to the grammar
+  <p>A conforming <dfn>TriG document</dfn> is a Unicode string that conforms to the grammar
     and additional constraints defined in <a href="#sec-grammar" class="sectionRef"></a>,
     starting with the <a href="#grammar-production-trigDoc"><code>trigDoc</code> production</a>.
     A TriG document serializes an RDF dataset.</p>
 
-  <p>A conforming <strong>TriG parser</strong> is a system capable of reading TriG documents
+  <p>A conforming <dfn>TriG parser</dfn> is a system capable of reading TriG documents
     on behalf of an application. It makes the serialized RDF dataset,
     as defined in <a href="#sec-parsing" class="sectionRef"></a>,
     available to the application, usually through some form of API.</p>
@@ -280,7 +280,7 @@
     <p>White space (production <a href="#grammar-production-WS">WS</a>)
       is used to separate two terminals which would otherwise be (mis-)recognized as one terminal.
       Rule names below in capitals indicate where white space is significant;
-      these form a possible choice of terminals for constructing a TriG parser.</p>
+      these form a possible choice of terminals for constructing a <a>TriG parser</a>.</p>
 
     <p>White space is significant in the production <a href="#grammar-production-String">String</a>.</p>
   </section>
@@ -765,6 +765,69 @@
     </section>
   </section>
 </section>
+<section id="privacy-considerations">
+  <h2>Privacy Considerations</h2>
+  <p class="ednote">TODO</p>  
+</section>
+
+<section id="security">
+  <h2>Security Considerations</h2>
+
+  <p>The <a href="#grammar-production-STRING_LITERAL_SINGLE_QUOTE">STRING_LITERAL_SINGLE_QUOTE</a>,
+    <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>,
+    <a href="#grammar-production-STRING_LITERAL_LONG_SINGLE_QUOTE">STRING_LITERAL_LONG_SINGLE_QUOTE</a>, and
+    <a href="#grammar-production-STRING_LITERAL_LONG_QUOTE">STRING_LITERAL_LONG_QUOTE</a>,
+    productions allows the use of unescaped control characters.
+    Although this specification does not directly expose this content to an end user,
+    it might be presented through a user agent, which may cause the presented text to 
+    be obfuscated due to presentation of such characters.</p>
+
+  <p>TriG is a general-purpose assertion language;
+    applications may evaluate given data to infer more assertions or to dereference <a data-cite="RDF12-CONCEPTS#dfn-iri">IRIs</a>,
+    invoking the security considerations of the scheme for that IRI.
+    Note in particular, the privacy issues in [[RFC3023]] section 10 for HTTP IRIs.
+    Data obtained from an inaccurate or malicious data source may lead to inaccurate or misleading conclusions,
+    as well as the dereferencing of unintended IRIs.
+    Care must be taken to align the trust in consulted resources with the sensitivity of
+    the intended use of the data;
+    inferences of potential medical treatments would likely require different trust than inferences
+    for trip planning.</p>
+
+  <p>The TriG language is used to express arbitrary application data;
+    security considerations will vary by domain of use.
+    Security tools and protocols applicable to text
+    (for example, PGP encryption, checksum validation, password-protected compression)
+    may also be used on <a>TriG documents</a>.
+    Security/privacy protocols must be imposed which reflect the sensitivity of the embedded information.</p>
+
+  <p>TriG can express data which is presented to the user, such as RDF Schema labels.
+    Applications rendering strings retrieved from untrusted <a>TriG documents</a>,
+    or using unescaped characters,
+    SHOULD use warnings and other appropriate means to limit the possibility
+    that malignant strings might be used to mislead the reader.
+    The security considerations in the media type registration for XML ([[!RFC3023]] section 10)
+    provide additional guidance around the expression of arbitrary data and markup.</p>
+
+  <p>TriG uses <a data-cite="RDF12-CONCEPTS#dfn-iri">IRIs</a> as term identifiers.
+    Applications interpreting data expressed in TriG SHOULD address the security issues of
+    [[[!RFC3987]]] [[!RFC3987]] Section 8, as well as
+    [[[!RFC3986]]] [[!RFC3986]] Section 7.</p>
+
+  <p>Multiple <a data-cite="RDF12-CONCEPTS#dfn-iri">IRIs</a> may have the same appearance.
+    Characters in different scripts may look similar (for instance,
+    a Cyrillic &quot;&#1086;&quot; may appear similar to a Latin &quot;o&quot;).
+    A character followed by combining characters may have the same visual representation
+    as another character (for example, LATIN SMALL LETTER "E" followed by COMBINING ACUTE
+    ACCENT has the same visual representation as LATIN SMALL LETTER "E" WITH ACUTE).
+    <!-- (<code>foo:resum&#40751;code> and <code>f&#1086;&#1086;:resume&#769;</code>)-->
+    Any person or application that is writing or interpreting data in TriG
+    must take care to use the IRI that matches the intended semantics,
+    and avoid IRIs that may look similar.
+    Further information about matching visually similar characters can be found
+    in [[[UNICODE-SECURITY]]] [[UNICODE-SECURITY]] and
+    [[[RFC3987]]] [[RFC3987]] Section 8.</p>
+
+</section>
 
 <section id="Acknowledgments" class="informative">
   <h2>Acknowledgments</h2>
@@ -821,7 +884,8 @@
   <h2>Changes between RDF 1.1 and RDF 1.2</h2>
 
   <ul>
-    
+    <li>Separated <a href="#security"></a> from <a href="#sec-mediaReg"></a>
+      and updated language.</li>
   </ul>
 </section>
 
@@ -856,47 +920,7 @@
     <dd>Unicode code points may also be expressed using an \uXXXX (U+0000 to U+FFFF)
       or \UXXXXXXXX syntax (for U+10000 onwards) where X is a hexadecimal digit [0-9A-Fa-f]</dd>
     <dt>Security considerations:</dt>
-    <dd>TriG is a general-purpose assertion language;
-      applications may evaluate given data to infer more assertions or to dereference IRIs,
-      invoking the security considerations of the scheme for that IRI.
-      Note in particular, the privacy issues in [[!RFC3023]] section 10 for HTTP IRIs.
-      Data obtained from an inaccurate or malicious data source may lead to inaccurate
-      or misleading conclusions, as well as the dereferencing of unintended IRIs.
-      Care must be taken to align the trust in consulted resources with the sensitivity
-      of the intended use of the data;
-      inferences of potential medical treatments would likely require different trust
-      than inferences for trip planning.</dd>
-
-    <dd>TriG is used to express arbitrary application data; security considerations
-      will vary by domain of use. Security tools and protocols applicable to text
-      (e.g. PGP encryption, MD5 sum validation, password-protected compression)
-      may also be used on TriG documents. Security/privacy protocols
-      must be imposed which reflect the sensitivity of the embedded information.</dd>
-    <dd>TriG can express data which is presented to the user,
-      for example, RDF Schema labels. Application rendering strings retrieved from untrusted TriG documents
-      must ensure that malignant strings may not be used to mislead the reader.
-      The security considerations in the media type registration for XML
-      ([[!RFC3023]] section 10) provide additional guidance around the expression
-      of arbitrary data and markup.</dd>
-    <dd>TriG uses IRIs as term identifiers. Applications interpreting data expressed in TriG
-      should address the security issues of
-      [[[!RFC3987]]] [[!RFC3987]] Section 8,
-      as well as [[[!RFC3986]]] [[!RFC3986]] Section 7.</dd>
-
-    <dd>Multiple IRIs may have the same appearance. Characters in different scripts may
-      look similar (a Cyrillic &quot;&#1086;&quot; may appear similar to a Latin &quot;o&quot;).
-      A character followed by combining characters may have the same visual representation
-      as another character
-      (LATIN SMALL LETTER E followed by COMBINING ACUTE ACCENT has the same visual representation
-      as LATIN SMALL LETTER E WITH ACUTE).
-      <!-- (<code>foo:resum&#40751;code> and <code>f&#1086;&#1086;:resume&#769;</code>)-->
-      Any person or application that is writing or interpreting data in TriG
-      must take care to use the IRI that matches the intended semantics,
-      and avoid IRIs that make look similar.
-      Further information about matching of similar characters can be found
-      in [[[UNICODE-SECURITY]]] [[UNICODE-SECURITY]] and
-      [[[RFC3987]]] [[RFC3987]], Section 8.</dd>
-
+    <dd>See <a href="#security" class="sectionRef"></a>.</dd>
     <dt>Interoperability considerations:</dt>
     <dd>There are no known interoperability issues.</dd>
     <dt>Published specification:</dt>


### PR DESCRIPTION
Also adds sub Privacy Considerations section and minor cleanup of conformance.

Defines TriG document and TriG parser terms.

Fixes #6.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-trig/pull/12.html" title="Last updated on Apr 5, 2023, 7:19 PM UTC (14c5422)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-trig/12/51e0df9...14c5422.html" title="Last updated on Apr 5, 2023, 7:19 PM UTC (14c5422)">Diff</a>