### PR TITLE
add LANG-SUBTAG-REGISTRY - now it's on Normative Refs

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -619,7 +619,7 @@
           match the pattern for <a href="#grammar-production-LANGTAG">LANGTAG</a>,
           though neither "<code class="grammar-literal">prefix</code>"
           nor "<code class="grammar-literal">base</code>"
-          are <a data-cite="?LANG-SUBTAG-REGISTRY#">registered language subtags</a>.
+          are <a data-cite="?LANG-SUBTAG-REGISTRY#">registered language subtags</a> [[LANG-SUBTAG-REGISTRY]].
           This specification does not define whether a quoted literal followed by
           either of these tokens (e.g., <code>"Z"@base</code>) is in the TriG language.
         </li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -619,7 +619,7 @@
           match the pattern for <a href="#grammar-production-LANGTAG">LANGTAG</a>,
           though neither "<code class="grammar-literal">prefix</code>"
           nor "<code class="grammar-literal">base</code>"
-          are <a data-cite="?LANG-SUBTAG-REGISTRY#">registered language subtags</a> [[LANG-SUBTAG-REGISTRY]].
+          are <a data-cite="LANG-SUBTAG-REGISTRY#">registered language subtags</a> [[LANG-SUBTAG-REGISTRY]].
           This specification does not define whether a quoted literal followed by
           either of these tokens (e.g., <code>"Z"@base</code>) is in the TriG language.
         </li>


### PR DESCRIPTION
Add a ref explicitly


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-trig/pull/28.html" title="Last updated on Sep 21, 2023, 9:00 PM UTC (d88569f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-trig/28/da74de7...d88569f.html" title="Last updated on Sep 21, 2023, 9:00 PM UTC (d88569f)">Diff</a>