### PR TITLE
Randomly noticed grammar fix for index.html

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -202,7 +202,9 @@
       -->
     </pre>
 
-    <p>A <a data-cite="RDF12-CONCEPTS#dfn-rdf-dataset">RDF dataset</a> may contain a <a data-cite="RDF12-CONCEPTS#dfn-default-graph">default graph</a>, and <a data-cite="RDF12-CONCEPTS#dfn-named-graph">named graphs</a>.</p>
+    <p>An <a data-cite="RDF12-CONCEPTS#dfn-rdf-dataset">RDF dataset</a> may contain a
+      <a data-cite="RDF12-CONCEPTS#dfn-default-graph">default graph</a> and/or zero
+      or more <a data-cite="RDF12-CONCEPTS#dfn-named-graph">named graphs</a>.</p>
 
     <pre id="ex-default-and-named-graphs"
          class="example trig" data-transform="updateExample"


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TallTed/rdf-trig/pull/30.html" title="Last updated on Oct 13, 2023, 3:51 AM UTC (2cafb0a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-trig/30/a8a4970...TallTed:2cafb0a.html" title="Last updated on Oct 13, 2023, 3:51 AM UTC (2cafb0a)">Diff</a>