### PR TITLE
Updates test suite location

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -10,7 +10,7 @@
     var respecConfig = {
       localBiblio:          localBibliography,
       specStatus:           "ED",
-      testSuiteURI:         "https://w3c.github.io/rdf-tests/trig/",
+      testSuiteURI:         "https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig/",
       edDraftURI:           "https://w3c.github.io/rdf-trig/spec/",
       shortName:            "rdf12-trig",
       subtitle:             "RDF Dataset Language",


### PR DESCRIPTION
New location is https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-trig, which also includes RDF 1.1 tests.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-trig/pull/32.html" title="Last updated on Nov 3, 2023, 8:08 PM UTC (efa641f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-trig/32/31caead...efa641f.html" title="Last updated on Nov 3, 2023, 8:08 PM UTC (efa641f)">Diff</a>