### PR TITLE
Grammar updates for triple terms and occurrences

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -296,8 +296,8 @@
       PREFIX :    <http://www.example.org/>
       PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
-                             _:e38 :familyName   "Smith" .
-      _:anno rdf:reifies <<( _:e38 :jobTitle     "Designer" )>> .
+                             _:e38  :familyName  "Smith" .
+      _:anno rdf:reifies <<( _:e38  :jobTitle    "Designer" )>> .
                              _:anno :accordingTo _:e22 .
       -->
     </pre>

--- a/spec/index.html
+++ b/spec/index.html
@@ -109,7 +109,8 @@
     <a data-cite="RDF12-CONCEPTS#dfn-dir-lang-string">directional language-tagged strings</a>
     with [[RDF12-TURTLE]].</p>
 
-  <p>In addition, RDF 1.2 TriG shares the <a data-cite="RDF12-TURTLE#annotation-syntax">annotation syntax</a> with [[RDF12-TURTLE]] which allows
+  <p>In addition, RDF 1.2 TriG shares the <a data-cite="RDF12-TURTLE#reifying-triples">reifying triples</a> and
+    <a data-cite="RDF12-TURTLE#annotation-syntax">annotation syntax</a> extensions with [[RDF12-TURTLE]] which allows
     <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a> to also be <a data-cite="RDF12-CONCEPTS#dfn-asserted-triple">asserted</a>.</p>
 </section>
 
@@ -282,31 +283,23 @@
 
   </section>
 
-  <section id="reifications">
-    <h3>Reifications</h3>
+  <section id="triple-terms">
+    <h3>Triple Terms</h3>
 
+    <p>TriG shares the same syntax for representing <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a>
+      as Turtle, including <a data-cite="RDF12-TURTLE#reifying-triples">Reifying Triples</a>
+      and the <a data-cite="RDF12-TURTLE#annotation-syntax">Annotation Syntax</a>.</p>
 
-    <p class="note"><a data-cite="RDF12-CONCEPTS#dfn-reification">Reification</a> in RDF 1.2 is a concept distinct from the
-      <a data-cite="RDF12-SEMANTICS#Reif">Reification vocabulary</a> originally
-      defined in <a data-cite="RDF-MT#Reif">RDF Semantics</a>.
-      While both terms describe a representation of an RDF triple using components,
-      RDF 1.2 uses the term to identify a <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a>
-      using the `rdf:reifies` predicate.</p>
+    <pre id="ex-triple-term" class="example turtle" data-transform="updateExample"
+         title="Triple Term">
+      <!--
+      PREFIX :    <http://www.example.org/>
+      PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
-    <p>TriG shares the same syntax for representing <dfn data-cite="RDF12-CONCEPTS#dfn-triple-terms">triple terms</dfn>
-      as Turtle, including the <a data-cite="RDF12-TURTLE#annotation-syntax">Annotation Syntax</a>.</p>
-
-    <pre id="ex-annotated-triple"
-         class="example trig"
-         data-transform="updateExample"
-         title="TriG annotated triples">
-    <!--
-      BASE <http://example.org/>
-      PREFIX : <#>
-      :G {
-        _:a :name "Alice" {| :t | :statedBy :bob |} .
-      }
-    -->
+      _:e38  :familyName                     "Smith" .
+      _:anno rdf:reifies <<( _:e38 :jobTitle "Designer" )>> .
+      _:anno :accordingTo                     _:e22 .
+      -->
     </pre>
 
   </section>
@@ -755,7 +748,7 @@
     <a data-cite="RDF12-CONCEPTS#dfn-iri">IRIs</a>,
     <a data-cite="RDF12-CONCEPTS#dfn-literal">literals</a>,
     <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank nodes</a>, and
-    <a data-cite="RDF12-CONCEPTS#dfn-triple terms">triple terms</a>.
+    <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a>.
 
     Literals are composed of a <a data-cite="RDF12-CONCEPTS#dfn-lexical-form">lexical form</a>
     and an optional <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a> [[!BCP47]]
@@ -770,7 +763,7 @@
 
   <section id="sec-parsing-state">
     <h3>Parser State</h3>
-    <p>Parsing TriG requires a state of seven items:</p>
+    <p>Parsing TriG requires a state of nine items:</p>
 
     <ul>
       <li id="baseURI">IRI |baseURI|
@@ -786,15 +779,19 @@
         per the <a href="#grammar-production-PNAME_NS"><code>PNAME_NS</code></a> production: <code>PN_PREFIX? ":"</code>.</li>
       <li id="bnodeLabels">Map[string -&gt; <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a>] |bnodeLabels|
         — A mapping from string to blank node.</li>
-      <li id="curSubject">RDF_Term |curSubject|
+      <li id="curSubject"><a data-cite="RDF12-CONCEPTS#dfn-rdf-term">RDF Term</a> |curSubject|
         — The |curSubject| is bound to the
-        <a href="#grammar-production-subject"><code>subject</code></a> production</li>
-      <li id="curPredicate"><a data-cite="RDF12-CONCEPTS#dfn-rdf-term">RDF Term</a> |curPredicate|
-        — The |curPredicate| is bound to
+        <a href="#grammar-production-subject"><code>subject</code></a>,
+        <a href="#grammar-production-blankNodePropertyList"><code>blankNodePropertyList</code></a>,
+        <a href="#grammar-production-collection"><code>collection</code></a>,
+        <a href="#grammar-production-tripleTerm"><code>tripleTerm</code></a>, and
+        <a href="#grammar-production-annotationBlock"><code>annotationBlock</code></a>
+         productions.</li>
+      <li id="curPredicate">RDF_Term |curPredicate|
+        — The |curPredicate| is bound to the
         the <a href="#grammar-production-verb"><code>verb</code></a> production.
-        If token matched was <a href="#cp-lowercase-a"><code title="latin small letter A">a</code></a>,
-        |curPredicate| is bound to the IRI
-        <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#type</code>.</li>
+        If token matched was <a href="#cp-lowercase-a"><code title="latin-small-letter-a">a</code></a>, |curPredicate|
+        is bound to the IRI <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#type</code>.</li>
       <li id="curObject"><a data-cite="RDF12-CONCEPTS#dfn-rdf-term">RDF Term</a> |curObject| —
         The |curObject| is bound to the
         <a href="#grammar-production-object"><code>object</code></a> and
@@ -805,7 +802,17 @@
         produced in parsing.  When undefined, triples are destined
         for the <a data-cite="RDF12-CONCEPTS#dfn-default-graph">default graph</a>.
       </li>
+      <li id="curReifier"><a data-cite="RDF12-CONCEPTS#dfn-rdf-term">RDF Term</a> |curReifier| —
+        The |curReifier| is bound to the
+        <a href="#grammar-production-reifier"><code>reifier</code></a> and
+        <a href="#grammar-production-annotationBlock"><code>annotationBlock</code></a> productions.</li>
+      <li id="curTripleTerm"><a data-cite="RDF12-CONCEPTS#dfn-triple-term">Triple term</a> |curTripleTerm| —
+        The |curTripleTerm| is set in the <a href="#annotation">Annotations</a> constructor.
+      </li>
     </ul>
+
+    <p>Term Constructors can create a stack of these values indicated by
+      using language such as "records the |curSubject| and |curPredicate|."</p>
   </section>
 
   <section  id="sec-parsing-terms">
@@ -839,33 +846,35 @@
         <tr id="handle-blankNodePropertyList"           ><td style="text-align:left;"            ><a class="type bNode"       href="#grammar-production-blankNodePropertyList"           ><code>blankNodePropertyList</code></a></td><td><a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node  </a></td><td>A blank node is generated. Note the rules for <code>blankNodePropertyList</code> in the next section.</td></tr>
         <tr id="handle-collection"                      ><td style="text-align:left;" rowspan="2"><a class="type bNode"       href="#grammar-production-collection"                      ><code>collection</code>         </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-blank-node">  blank node  </a></td><td>For non-empty lists, a blank node is generated. Note the rules for <code>collection</code> in the next section.</td></tr>
         <tr id="handle-collection-IRI"                  ><td                                                                                                                                                                          ><a data-cite="RDF12-CONCEPTS#dfn-iri">         IRI         </a></td><td>For empty lists, the resulting IRI is <code>rdf:nil</code>. Note the rules for <code>collection</code> in the next section.</td></tr>
-        <tr id="handle-tripleTerm"                    ><td style="text-align:left;"            ><a class="type tripleTerm" href="#grammar-production-tripleTerm"                    >tripleTerm                    </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a></td>
+        <tr id="handle-reifier"                         ><td style="text-align:left;"            ><a class="type reifier" href="#grammar-production-reifier"                              >reifier                         </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-iri">          IRI          </a>
+                                                                                                                                                                                                                                      | <a data-cite="RDF12-CONCEPTS#dfn-blank-node">   blank node   </a></td>
+          <td>
+            The |curReifier| is taken from <a data-cite="RDF12-CONCEPTS#dfn-rdf-term">term</a>, which is taken from the matched
+            <a href="#grammar-production-iri"><code>iri</code></a> production
+            or <a href="#grammar-production-BlankNode"><code>BlankNode</code></a> production, if any.
+            If no such production is matched, <a data-cite="RDF12-CONCEPTS#dfn-rdf-term">term</a> is taken
+            from a fresh RDF <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a>.
+          </td>
+        </tr>
+        <tr id="handle-tripleTerm"                      ><td style="text-align:left;"            ><a class="type tripleTerm"   href="#grammar-production-tripleTerm"                      >tripleTerm                      </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-triple-term">  triple term  </a></td>
           <td>
             The <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>
             is composed of the terms constructed from
-            the <a href="#grammar-production-subject"><code>subject</code></a>,
+            the <a href="#grammar-production-ttSubject"><code>ttSubject</code></a>,
             <a href="#grammar-production-predicate"><code>predicate</code></a>, and
-            <a href="#grammar-production-object"><code>object</code></a> productions.
+            <a href="#grammar-production-ttObject"><code>ttObject</code></a> productions.
           </td>
         </tr>
-        <tr id="handle-reification"                     ><td style="text-align:left;"            ><a class="type reification" href="#grammar-production-reification"                      >reification                     </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-iri">IRI</a> | <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a></td>
+        <tr id="handle-reifiedTriple"                   ><td style="text-align:left;"            ><a class="type reifiedTriple" href="#grammar-production-reifiedTriple"                  >reifiedTriple                   </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-iri">IRI</a> | <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a></td>
           <td>
-            The <a class="type reification" href="#grammar-production-reification">reification</a> production
-            defines an RDF term in addition to a <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>.
-            The term constructed from this production
-            is composed of an identifier from either the <a href="#grammar-production-iri"><code>iri</code></a>
-            or <a href="#grammar-production-BlankNode"><code>BlankNode</code></a> productions,
-            if present, otherwise from a fresh RDF <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a>.
+            The <a data-cite="RDF12-CONCEPTS#dfn-rdf-term">term</a> is taken from the matched <a href="#grammar-production-reifier"><code>reifier</code></a>, if any,
+            or from a fresh RDF <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a>.
           </td>
         </tr>
-        <tr id="handle-annotation"                      ><td style="text-align:left;"            ><a class="type annotation" href="#grammar-production-annotation"                        >annotation                      </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-iri">IRI</a> | <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a></td>
+        <tr id="handle-annotationBlock"                 ><td style="text-align:left;"            ><a class="type annotation" href="#grammar-production-annotationBlock"                   >annotationBlock                 </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-iri">IRI</a> | <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a></td>
           <td>
-            The <a href="#grammar-production-annotation"><code>annotation</code></a> production
-            defines an RDF term in addition to a <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>.
-            The term constructed from this production
-            is composed of an identifier from either the <a href="#grammar-production-iri"><code>iri</code></a>
-            or <a href="#grammar-production-BlankNode"><code>BlankNode</code></a> productions,
-            if present, otherwise from a fresh RDF <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a>.
+            The <a data-cite="RDF12-CONCEPTS#dfn-rdf-term">term</a> is taken from a previously matched <a data-cite="RDF12-CONCEPTS#dfn-reifier">reifier</a>, if any,
+            or from a fresh RDF <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a>.
           </td>
         </tr>
       </tbody>
@@ -917,18 +926,6 @@
         before handling the <a href="#grammar-production-predicateObjectList"><code>predicateObjectList</code></a> production
         in rule <a href="#grammar-production-triplesOrGraph"><code>triplesOrGraph</code></a>.
       </p>
-
-      <p>Beginning the <a href="#grammar-production-quotedTriple"><code>quotedTriple</code></a> production
-        records the |curSubject| and |curPredicate|.
-        Finishing the <a href="#grammar-production-quotedTriple"><code>quotedTriple</code></a> production
-        yields the RDF triple |curSubject| |curPredicate| |curObject|
-        and restores the recorded values of |curSubject| and |curPredicate|.</p>
-
-      <p>Beginning the <a href="#grammar-production-annotation"><code>annotation</code></a> production
-        records the |curSubject| and |curPredicate|,
-        and sets the |curSubject| to the RDF triple |curSubject| |curPredicate| |curObject|.
-        Finishing the <a href="#grammar-production-annotation"><code>annotation</code></a> production
-
     </section>
 
     <section id="triple-output">
@@ -962,45 +959,58 @@
       </p>
     </section>
 
-    <section id="tripleTerm">
-      <h4 style="padding-bottom:0; margin-bottom:0;">Triple Terms</h4>
+    <section id="reifier">
+      <h4>Reifiers</h4>
 
-      <p>Beginning the <a href="#grammar-production-tripleTerm"><code>tripleTerm</code></a> production
-        records the |curSubject| and |curPredicate|.
-        Finishing the <a href="#grammar-production-tripleTerm"><code>tripleTerm</code></a> production
-        and restores the recorded values of |curSubject| and |curPredicate|.</p>
+      <p>Beginning the <a href="#grammar-production-reifier"><code>reifier</code></a> production,
+        the |curReifier| is taken from the <a href="#handle-reifier"><code>reifier</code></a> term constructor.
+        Then yield the the RDF triple |curReifier| <code>rdf:reifies</code> |curTripleTerm|.</p>
     </section>
 
-    <section id="reification">
-      <h4 style="padding-bottom:0; margin-bottom:0;">Reifications</h4>
+    <section id="reifiedTriple">
+      <h4>Reified Triples</h4>
 
-      <p>Beginning the <a href="#grammar-production-reification"><code>reification</code></a> production
-        records the |curSubject| and |curPredicate|.
-        |curSubject| is taken from the
-        <a href="#handle-reification"><code>reification</code></a> term constructor.
-        A new <a href="#grammar-production-tripleTerm"><code>tripleTerm</code></a> instance |TT|
-        is composed from
-        the <a href="#grammar-production-subject"><code>subject</code></a>,
-        <a href="#grammar-production-predicate"><code>predicate</code></a>, and
+      <p>Beginning the <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a> production
+        records the |curTripleTerm|.
+        A new <a href="#grammar-production-tripleTerm"><code>tripleTerm</code></a> instance |curTripleTerm|
+        is created using the
+        <a href="#grammar-production-subject"><code>subject</code></a>,
+        <a href="#grammar-production-verb"><code>verb</code></a>, and
         <a href="#grammar-production-object"><code>object</code></a> productions.
-        Finishing the <a href="#grammar-production-reification"><code>reification</code></a> production
-        yields the RDF triple |curSubject| <code>rdf:reifies</code> |TT|
-        and restores the recorded values of |curSubject| and |curPredicate|.</p>
-    </section>
 
+        Finishing the <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a> production,
+        if the |curReifier| is not set, it is assigned a fresh RDF <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a>;
+        it then yields the RDF triple |curReifier| <code>rdf:reifies</code> |curTripleTerm|,
+        and then restores the recorded value of the |curTripleTerm|.
+        The node produced by matching <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a>
+        is the the |curReifier|.</p>
+    </section>
 
     <section id="annotation">
-      <h4 style="padding-bottom:0; margin-bottom:0;">Annotations</h4>
+      <h4>Annotations</h4>
 
       <p>Beginning the <a href="#grammar-production-annotation"><code>annotation</code></a> production
         records the |curSubject| and |curPredicate|.
-        A new <a href="#grammar-production-tripleTerm"><code>tripleTerm</code></a> instance |TT|
-        is created using |curSubject| |curPredicate| |curObject|.
-        The identifier |TI| is taken from the
-        <a href="#handle-annotation"><code>annotation</code></a> term constructor.
+        A new <a href="#grammar-production-tripleTerm"><code>tripleTerm</code></a> instance |curTripleTerm|
+        is created using the |curSubject| |curPredicate| |curObject|,
+        and the value of the |curReifier| is cleared.
         Finishing the <a href="#grammar-production-annotation"><code>annotation</code></a> production
-        yields the RDF triple |TI| <code>rdf:reifies</code> |TT|
-        and restores the recorded values of |curSubject| and |curPredicate|.</p>
+        restores the recorded values of the |curSubject| and |curPredicate|.</p>
+    </section>
+
+    <section id="annotationBlock">
+      <h4>Annotation Blocks</h4>
+
+      <p>Beginning the <a href="#grammar-production-annotationBlock"><code>annotationBlock</code></a> production records the |curTripleTerm|.
+        If the |curReifier| is not set, then the |curReifier| is assigned a fresh RDF <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a>
+        and the production yields the RDF triple |curReifier| <code>rdf:reifies</code> |curTripleTerm|.
+        The |curSubject| is taken from the |curReifier|
+        Finishing the <a href="#grammar-production-annotationBlock"><code>annotationBlock</code></a> production,
+        clears the value of the |curReifier|,
+        and restores the |curTripleTerm|.</p>
+      <p class="note">If the |curReifier| was already set, the
+        reifyiing triple |curReifier| <code>rdf:reifies</code> |curTripleTerm|
+        was emitted in <a href="#reifier"></a>.</p>
     </section>
 
     <section id="propertyList">
@@ -1205,8 +1215,8 @@
     <li>Changes the `LANGTAG` terminal production to
       <a href="#grammar-production-LANG_DIR" class="type langDir"><code>LANG_DIR</code></a> to include
       an optional <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>.</li>
-    <li>Added <a href="#reifications" class="sectionRef sec-ref"><bdi class="secno">2.3 </bdi>Reifications</a> for representing 
-      <a>triple terms</a> in TriG.</li>
+    <li>Added <a href="#triple-terms" class="sectionRef">Triple Terms</a> for representing 
+      <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a> in TriG.</li>
     <li>Removed the `NIL` terminal production from the grammar, which was unused.</li>
   </ul>
 </section>

--- a/spec/index.html
+++ b/spec/index.html
@@ -965,6 +965,47 @@
       </p>
     </section>
 
+    <section id="tripleTerm">
+      <h4 id="tripleTerm" style="padding-bottom:0; margin-bottom:0;">Triple Terms</h4>
+
+      <p>Beginning the <a href="#grammar-production-tripleTerm"><code>tripleTerm</code></a> production
+        records the |curSubject| and |curPredicate|.
+        Finishing the <a href="#grammar-production-tripleTerm"><code>tripleTerm</code></a> production
+        and restores the recorded values of |curSubject| and |curPredicate|.</p>
+    </section>
+
+    <section id="reification">
+      <h4 style="padding-bottom:0; margin-bottom:0;">Reifications</h4>
+
+      <p>Beginning the <a href="#grammar-production-reification"><code>reification</code></a> production
+        records the |curSubject| and |curPredicate|.
+        |curSubject| is taken from the
+        <a href="#handle-reification"><code>reification</code></a> term constructor.
+        A new <a href="#grammar-production-tripleTerm"><code>tripleTerm</code></a> instance |TT|
+        is composed from
+        the <a href="#grammar-production-subject"><code>subject</code></a>,
+        <a href="#grammar-production-predicate"><code>predicate</code></a>, and
+        <a href="#grammar-production-object"><code>object</code></a> productions.
+        Finishing the <a href="#grammar-production-reification"><code>reification</code></a> production
+        yields the RDF triple |curSubject| <code>rdf:reifies</code> |TT|
+        and restores the recorded values of |curSubject| and |curPredicate|.</p>
+    </section>
+
+
+    <section id="annotation">
+      <h4 style="padding-bottom:0; margin-bottom:0;">Annotations</h4>
+
+      <p>Beginning the <a href="#grammar-production-annotation"><code>annotation</code></a> production
+        records the |curSubject| and |curPredicate|.
+        A new <a href="#grammar-production-tripleTerm"><code>tripleTerm</code></a> instance |TT|
+        is created using |curSubject| |curPredicate| |curObject|.
+        The identifier |TI| is taken from the
+        <a href="#handle-annotation"><code>annotation</code></a> term constructor.
+        Finishing the <a href="#grammar-production-annotation"><code>annotation</code></a> production
+        yields the RDF triple |TI| <code>rdf:reifies</code> |TT|
+        and restores the recorded values of |curSubject| and |curPredicate|.</p>
+    </section>
+
     <section id="propertyList">
       <h4 style="padding-bottom:0; margin-bottom:0;">Property Lists</h4>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -286,7 +286,7 @@
     <h3>Reifications</h3>
 
 
-    <p class="note"><a>Reification</a> in RDF 1.2 is a concept distinct from the
+    <p class="note"><a data-cite="RDF12-CONCEPTS#dfn-reification">Reification</a> in RDF 1.2 is a concept distinct from the
       <a data-cite="RDF12-SEMANTICS#Reif">Reification vocabulary</a> originally
       defined in <a data-cite="RDF-MT#Reif">RDF Semantics</a>.
       While both terms describe a representation of an RDF triple using components,

--- a/spec/index.html
+++ b/spec/index.html
@@ -788,17 +788,17 @@
         — A mapping from string to blank node.</li>
       <li id="curSubject">RDF_Term |curSubject|
         — The |curSubject| is bound to the
-        <a href="#grammar-production-subject"><code>subject</code></a>
-        and <a href="#grammar-production-qtSubject"><code>qtSubject</code></a> productions.</li>
-      <li id="curPredicate">RDF_Term |curPredicate|
-        — The |curPredicate| is bound to the
-        <a href="#grammar-production-verb"><code>verb</code></a> production.
-        If token matched was <a href="#cp-lowercase-a"><code title="latin-small-letter-a">a</code></a>, |curPredicate|
-        is bound to the IRI <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#type</code>.</li>
-      <li id="curObject">RDF_Term |curObject| —
+        <a href="#grammar-production-subject"><code>subject</code></a> production</li>
+      <li id="curPredicate"><a data-cite="RDF12-CONCEPTS#dfn-rdf-term">RDF Term</a> |curPredicate|
+        — The |curPredicate| is bound to
+        the <a href="#grammar-production-verb"><code>verb</code></a> production.
+        If token matched was <a href="#cp-lowercase-a"><code title="latin small letter A">a</code></a>,
+        |curPredicate| is bound to the IRI
+        <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#type</code>.</li>
+      <li id="curObject"><a data-cite="RDF12-CONCEPTS#dfn-rdf-term">RDF Term</a> |curObject| —
         The |curObject| is bound to the
         <a href="#grammar-production-object"><code>object</code></a> and
-        <a href="#grammar-production-qtObject"><code>qtObject</code></a> productions.</li>
+        <a href="#grammar-production-ttObject"><code>ttObject</code></a> productions.</li>
       <li id="curGraph">RDF_Term |curGraph| —
         The |curGraph| is bound to
         the label of the graph that is the destination of triples
@@ -806,9 +806,6 @@
         for the <a data-cite="RDF12-CONCEPTS#dfn-default-graph">default graph</a>.
       </li>
     </ul>
-    <p>Additionally, |curSubject|
-      can be bound to any RDF_Term
-      (including a <a>triple term</a>).</p>
   </section>
 
   <section  id="sec-parsing-terms">

--- a/spec/index.html
+++ b/spec/index.html
@@ -842,13 +842,33 @@
         <tr id="handle-blankNodePropertyList"           ><td style="text-align:left;"            ><a class="type bNode"       href="#grammar-production-blankNodePropertyList"           ><code>blankNodePropertyList</code></a></td><td><a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node  </a></td><td>A blank node is generated. Note the rules for <code>blankNodePropertyList</code> in the next section.</td></tr>
         <tr id="handle-collection"                      ><td style="text-align:left;" rowspan="2"><a class="type bNode"       href="#grammar-production-collection"                      ><code>collection</code>         </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-blank-node">  blank node  </a></td><td>For non-empty lists, a blank node is generated. Note the rules for <code>collection</code> in the next section.</td></tr>
         <tr id="handle-collection-IRI"                  ><td                                                                                                                                                                          ><a data-cite="RDF12-CONCEPTS#dfn-iri">         IRI         </a></td><td>For empty lists, the resulting IRI is <code>rdf:nil</code>. Note the rules for <code>collection</code> in the next section.</td></tr>
-        <tr id="handle-tripleTerm"                    ><td style="text-align:left;"            ><a class="type tripleTerm" href="#grammar-production-tripleTerm"                    >tripleTerm                    </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-triple0term">triple term</a></td>
+        <tr id="handle-tripleTerm"                    ><td style="text-align:left;"            ><a class="type tripleTerm" href="#grammar-production-tripleTerm"                    >tripleTerm                    </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a></td>
           <td>
             The <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>
             is composed of the terms constructed from
             the <a href="#grammar-production-subject"><code>subject</code></a>,
             <a href="#grammar-production-predicate"><code>predicate</code></a>, and
             <a href="#grammar-production-object"><code>object</code></a> productions.
+          </td>
+        </tr>
+        <tr id="handle-reification"                     ><td style="text-align:left;"            ><a class="type reification" href="#grammar-production-reification"                      >reification                     </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-iri">IRI</a> | <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a></td>
+          <td>
+            The <a class="type reification" href="#grammar-production-reification">reification</a> production
+            defines an RDF term in addition to a <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>.
+            The term constructed from this production
+            is composed of an identifier from either the <a href="#grammar-production-iri"><code>iri</code></a>
+            or <a href="#grammar-production-BlankNode"><code>BlankNode</code></a> productions,
+            if present, otherwise from a fresh RDF <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a>.
+          </td>
+        </tr>
+        <tr id="handle-annotation"                      ><td style="text-align:left;"            ><a class="type annotation" href="#grammar-production-annotation"                        >annotation                      </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-iri">IRI</a> | <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a></td>
+          <td>
+            The <a href="#grammar-production-annotation"><code>annotation</code></a> production
+            defines an RDF term in addition to a <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>.
+            The term constructed from this production
+            is composed of an identifier from either the <a href="#grammar-production-iri"><code>iri</code></a>
+            or <a href="#grammar-production-BlankNode"><code>BlankNode</code></a> productions,
+            if present, otherwise from a fresh RDF <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a>.
           </td>
         </tr>
       </tbody>

--- a/spec/index.html
+++ b/spec/index.html
@@ -98,7 +98,7 @@
   Turtle [[RDF12-TURTLE]] format.
   </p>
 
-  <p>RDF 1.2 TriG shares <a>quoted triples</a> with [[RDF12-TURTLE]]
+  <p>RDF 1.2 TriG shares <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a> with [[RDF12-TURTLE]]
     as a fourth kind of <a data-cite="RDF12-CONCEPTS#dfn-rdf-term">RDF term</a>
     which can be used as the
     <a data-cite="RDF12-CONCEPTS#dfn-subject">subject</a> or
@@ -110,7 +110,7 @@
     with [[RDF12-TURTLE]].</p>
 
   <p>In addition, RDF 1.2 TriG shares the <a data-cite="RDF12-TURTLE#annotation-syntax">annotation syntax</a> with [[RDF12-TURTLE]] which allows
-    <a>quoted triples</a> to also be <a data-cite="RDF12-CONCEPTS#dfn-asserted-triple">asserted</a>.</p>
+    <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a> to also be <a data-cite="RDF12-CONCEPTS#dfn-asserted-triple">asserted</a>.</p>
 </section>
 
 <section id='sotd' class="updateable-rec">
@@ -282,10 +282,18 @@
 
   </section>
 
-  <section id="quoted-triples">
-    <h3>Quoted Triples</h3>
+  <section id="reifications">
+    <h3>Reifications</h3>
 
-    <p>TriG shares the same syntax for representing <dfn data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triples</dfn>
+
+    <p class="note"><a>Reification</a> in RDF 1.2 is a concept distinct from the
+      <a data-cite="RDF12-SEMANTICS#Reif">Reification vocabulary</a> originally
+      defined in <a data-cite="RDF-MT#Reif">RDF Semantics</a>.
+      While both terms describe a representation of an RDF triple using components,
+      RDF 1.2 uses the term to identify a <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a>
+      using the `rdf:reifies` predicate.</p>
+
+    <p>TriG shares the same syntax for representing <dfn data-cite="RDF12-CONCEPTS#dfn-triple-terms">triple terms</dfn>
       as Turtle, including the <a data-cite="RDF12-TURTLE#annotation-syntax">Annotation Syntax</a>.</p>
 
     <pre id="ex-annotated-triple"
@@ -296,7 +304,7 @@
       BASE <http://example.org/>
       PREFIX : <#>
       :G {
-        _:a :name "Alice" {| :statedBy :bob |} .
+        _:a :name "Alice" {| :t | :statedBy :bob |} .
       }
     -->
     </pre>
@@ -747,7 +755,7 @@
     <a data-cite="RDF12-CONCEPTS#dfn-iri">IRIs</a>,
     <a data-cite="RDF12-CONCEPTS#dfn-literal">literals</a>,
     <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank nodes</a>, and
-    <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triples</a>.
+    <a data-cite="RDF12-CONCEPTS#dfn-triple terms">triple terms</a>.
 
     Literals are composed of a <a data-cite="RDF12-CONCEPTS#dfn-lexical-form">lexical form</a>
     and an optional <a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a> [[!BCP47]]
@@ -800,7 +808,7 @@
     </ul>
     <p>Additionally, |curSubject|
       can be bound to any RDF_Term
-      (including a <a>quoted triple</a>).</p>
+      (including a <a>triple terms</a>).</p>
   </section>
 
   <section  id="sec-parsing-terms">
@@ -834,9 +842,9 @@
         <tr id="handle-blankNodePropertyList"           ><td style="text-align:left;"            ><a class="type bNode"       href="#grammar-production-blankNodePropertyList"           ><code>blankNodePropertyList</code></a></td><td><a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node  </a></td><td>A blank node is generated. Note the rules for <code>blankNodePropertyList</code> in the next section.</td></tr>
         <tr id="handle-collection"                      ><td style="text-align:left;" rowspan="2"><a class="type bNode"       href="#grammar-production-collection"                      ><code>collection</code>         </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-blank-node">  blank node  </a></td><td>For non-empty lists, a blank node is generated. Note the rules for <code>collection</code> in the next section.</td></tr>
         <tr id="handle-collection-IRI"                  ><td                                                                                                                                                                          ><a data-cite="RDF12-CONCEPTS#dfn-iri">         IRI         </a></td><td>For empty lists, the resulting IRI is <code>rdf:nil</code>. Note the rules for <code>collection</code> in the next section.</td></tr>
-        <tr id="handle-quotedTriple"                    ><td style="text-align:left;"            ><a class="type quotedTriple" href="#grammar-production-quotedTriple"                    >quotedTriple                    </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triple</a></td>
+        <tr id="handle-tripleTerm"                    ><td style="text-align:left;"            ><a class="type tripleTerm" href="#grammar-production-tripleTerm"                    >tripleTerm                    </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-triple0term">triple term</a></td>
           <td>
-            The <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triple</a>
+            The <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term/a>
             is composed of the terms constructed from
             the <a href="#grammar-production-subject"><code>subject</code></a>,
             <a href="#grammar-production-predicate"><code>predicate</code></a>, and

--- a/spec/index.html
+++ b/spec/index.html
@@ -101,7 +101,6 @@
   <p>RDF 1.2 TriG shares <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a> with [[RDF12-TURTLE]]
     as a fourth kind of <a data-cite="RDF12-CONCEPTS#dfn-rdf-term">RDF term</a>
     which can be used as the
-    <a data-cite="RDF12-CONCEPTS#dfn-subject">subject</a> or
     <a data-cite="RDF12-CONCEPTS#dfn-object">object</a> of another
     <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">triple</a>,
     making it possible to make statements about other statements.

--- a/spec/index.html
+++ b/spec/index.html
@@ -964,7 +964,6 @@
 
     <section id="tripleTerm">
       <h4 style="padding-bottom:0; margin-bottom:0;">Triple Terms</h4>
-```suggestion
 
       <p>Beginning the <a href="#grammar-production-tripleTerm"><code>tripleTerm</code></a> production
         records the |curSubject| and |curPredicate|.

--- a/spec/index.html
+++ b/spec/index.html
@@ -963,7 +963,8 @@
     </section>
 
     <section id="tripleTerm">
-      <h4 id="tripleTerm" style="padding-bottom:0; margin-bottom:0;">Triple Terms</h4>
+      <h4 style="padding-bottom:0; margin-bottom:0;">Triple Terms</h4>
+```suggestion
 
       <p>Beginning the <a href="#grammar-production-tripleTerm"><code>tripleTerm</code></a> production
         records the |curSubject| and |curPredicate|.

--- a/spec/index.html
+++ b/spec/index.html
@@ -980,7 +980,7 @@
 
         Finishing the <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a> production,
         if the |curReifier| is not set, it is assigned a fresh RDF <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a>;
-        it then yields the RDF triple |curReifier| <code>rdf:reifies</code> |curTripleTerm|,
+        it next yields the RDF triple |curReifier| <code>rdf:reifies</code> |curTripleTerm|,
         and then restores the recorded value of the |curTripleTerm|.
         The node produced by matching <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a>
         is the the |curReifier|.</p>
@@ -1002,14 +1002,14 @@
       <h4>Annotation Blocks</h4>
 
       <p>Beginning the <a href="#grammar-production-annotationBlock"><code>annotationBlock</code></a> production records the |curTripleTerm|.
-        If the |curReifier| is not set, then the |curReifier| is assigned a fresh RDF <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a>
+        If the |curReifier| is not set, then it is assigned a fresh RDF <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a>
         and the production yields the RDF triple |curReifier| <code>rdf:reifies</code> |curTripleTerm|.
         The |curSubject| is taken from the |curReifier|
-        Finishing the <a href="#grammar-production-annotationBlock"><code>annotationBlock</code></a> production,
-        clears the value of the |curReifier|,
+        Finishing the <a href="#grammar-production-annotationBlock"><code>annotationBlock</code></a> production
+        clears the value of the |curReifier|
         and restores the |curTripleTerm|.</p>
       <p class="note">If the |curReifier| was already set, the
-        reifyiing triple |curReifier| <code>rdf:reifies</code> |curTripleTerm|
+        reifying triple |curReifier| <code>rdf:reifies</code> |curTripleTerm|
         was emitted in <a href="#reifier"></a>.</p>
     </section>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -1167,6 +1167,8 @@
     <li>Changes the `LANGTAG` terminal production to
       <a href="#grammar-production-LANG_DIR" class="type langDir"><code>LANG_DIR</code></a> to include
       an optional <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>.</li>
+    <li>Added <a href="#reifications" class="sectionRef sec-ref"><bdi class="secno">2.3 </bdi>Reifications</a> for representing 
+      <a>triple terms</a> in TriG.</li>
     <li>Removed the `NIL` terminal production from the grammar, which was unused.</li>
   </ul>
 </section>

--- a/spec/index.html
+++ b/spec/index.html
@@ -296,9 +296,9 @@
       PREFIX :    <http://www.example.org/>
       PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
-      _:e38  :familyName                     "Smith" .
-      _:anno rdf:reifies <<( _:e38 :jobTitle "Designer" )>> .
-      _:anno :accordingTo                     _:e22 .
+                             _:e38 :familyName   "Smith" .
+      _:anno rdf:reifies <<( _:e38 :jobTitle     "Designer" )>> .
+                             _:anno :accordingTo _:e22 .
       -->
     </pre>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -808,7 +808,7 @@
     </ul>
     <p>Additionally, |curSubject|
       can be bound to any RDF_Term
-      (including a <a>triple terms</a>).</p>
+      (including a <a>triple term</a>).</p>
   </section>
 
   <section  id="sec-parsing-terms">
@@ -844,7 +844,7 @@
         <tr id="handle-collection-IRI"                  ><td                                                                                                                                                                          ><a data-cite="RDF12-CONCEPTS#dfn-iri">         IRI         </a></td><td>For empty lists, the resulting IRI is <code>rdf:nil</code>. Note the rules for <code>collection</code> in the next section.</td></tr>
         <tr id="handle-tripleTerm"                    ><td style="text-align:left;"            ><a class="type tripleTerm" href="#grammar-production-tripleTerm"                    >tripleTerm                    </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-triple0term">triple term</a></td>
           <td>
-            The <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term/a>
+            The <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>
             is composed of the terms constructed from
             the <a href="#grammar-production-subject"><code>subject</code></a>,
             <a href="#grammar-production-predicate"><code>predicate</code></a>, and

--- a/spec/trig-bnf.html
+++ b/spec/trig-bnf.html
@@ -101,7 +101,7 @@
       <td>[17]</td>
       <td><code>subject</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-iri">iri</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BlankNode">BlankNode</a> <code class="grammar-alt">|</code> <a href="#grammar-production-collection">collection</a> <code class="grammar-alt">|</code> <a href="#grammar-production-quotedTriple">quotedTriple</a></td>
+      <td><a href="#grammar-production-iri">iri</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BlankNode">BlankNode</a> <code class="grammar-alt">|</code> <a href="#grammar-production-collection">collection</a> <code class="grammar-alt">|</code> <a href="#grammar-production-reification">reification</a></td>
     </tr>
     <tr id="grammar-production-predicate">
       <td>[18]</td>
@@ -113,7 +113,7 @@
       <td>[19]</td>
       <td><code>object</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-iri">iri</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BlankNode">BlankNode</a> <code class="grammar-alt">|</code> <a href="#grammar-production-collection">collection</a> <code class="grammar-alt">|</code> <a href="#grammar-production-blankNodePropertyList">blankNodePropertyList</a> <code class="grammar-alt">|</code> <a href="#grammar-production-literal">literal</a> <code class="grammar-alt">|</code> <a href="#grammar-production-quotedTriple">quotedTriple</a></td>
+      <td><a href="#grammar-production-iri">iri</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BlankNode">BlankNode</a> <code class="grammar-alt">|</code> <a href="#grammar-production-collection">collection</a> <code class="grammar-alt">|</code> <a href="#grammar-production-blankNodePropertyList">blankNodePropertyList</a> <code class="grammar-alt">|</code> <a href="#grammar-production-literal">literal</a> <code class="grammar-alt">|</code> <a href="#grammar-production-tripleTerm">tripleTerm</a> <code class="grammar-alt">|</code> <a href="#grammar-production-reification">reification</a></td>
     </tr>
     <tr id="grammar-production-literal">
       <td>[20]</td>
@@ -175,29 +175,29 @@
       <td>::=</td>
       <td><a href="#grammar-production-BLANK_NODE_LABEL">BLANK_NODE_LABEL</a> <code class="grammar-alt">|</code> <a href="#grammar-production-ANON">ANON</a></td>
     </tr>
-    <tr id="grammar-production-quotedTriple">
+    <tr id="grammar-production-reification">
       <td>[30]</td>
-      <td><code>quotedTriple</code></td>
+      <td><code>reification</code></td>
       <td>::=</td>
-      <td>'<code class="grammar-literal">&lt;&lt;</code>' <a href="#grammar-production-qtSubject">qtSubject</a> <a href="#grammar-production-predicate">predicate</a> <a href="#grammar-production-qtObject">qtObject</a> '<code class="grammar-literal">&gt;&gt;</code>'</td>
+      <td>'<code class="grammar-literal">&lt;&lt;</code>' <code class="grammar-paren">(</code><code class="grammar-paren">(</code><a href="#grammar-production-iri">iri</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BlankNode">BlankNode</a><code class="grammar-paren">)</code> '<code class="grammar-literal">|</code>'<code class="grammar-paren">)</code><code class="grammar-opt">?</code> <a href="#grammar-production-subject">subject</a> <a href="#grammar-production-predicate">predicate</a> <a href="#grammar-production-object">object</a> '<code class="grammar-literal">&gt;&gt;</code>'</td>
     </tr>
-    <tr id="grammar-production-qtSubject">
+    <tr id="grammar-production-tripleTerm">
       <td>[31]</td>
-      <td><code>qtSubject</code></td>
+     <td><code>tripleTerm</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-iri">iri</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BlankNode">BlankNode</a> <code class="grammar-alt">|</code> <a href="#grammar-production-quotedTriple">quotedTriple</a></td>
+      <td>'<code class="grammar-literal">&lt;&lt;(</code>' <a href="#grammar-production-subject">subject</a> <a href="#grammar-production-predicate">predicate</a> <a href="#grammar-production-ttObject">ttObject</a> '<code class="grammar-literal">)&gt;&gt;</code>'</td>
     </tr>
-    <tr id="grammar-production-qtObject">
+    <tr id="grammar-production-ttObject">
       <td>[32]</td>
-      <td><code>qtObject</code></td>
+      <td><code>ttObject</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-iri">iri</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BlankNode">BlankNode</a> <code class="grammar-alt">|</code> <a href="#grammar-production-literal">literal</a> <code class="grammar-alt">|</code> <a href="#grammar-production-quotedTriple">quotedTriple</a></td>
+      <td><a href="#grammar-production-iri">iri</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BlankNode">BlankNode</a> <code class="grammar-alt">|</code> <a href="#grammar-production-literal">literal</a> <code class="grammar-alt">|</code> <a href="#grammar-production-tripleTerm">tripleTerm</a></td>
     </tr>
     <tr id="grammar-production-annotation">
       <td>[33]</td>
       <td><code>annotation</code></td>
       <td>::=</td>
-      <td>'<code class="grammar-literal">{|</code>' <a href="#grammar-production-predicateObjectList">predicateObjectList</a> '<code class="grammar-literal">|}</code>'</td>
+      <td>'<code class="grammar-literal">{|</code>' <code class="grammar-paren">(</code><code class="grammar-paren">(</code><a href="#grammar-production-iri">iri</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BlankNode">BlankNode</a><code class="grammar-paren">)</code> '<code class="grammar-literal">|</code>'<code class="grammar-paren">)</code><code class="grammar-opt">?</code> <a href="#grammar-production-predicateObjectList">predicateObjectList</a> '<code class="grammar-literal">|}</code>'</td>
     </tr>
     <tr id="grammar-declaration-terminals">
       <td colspan="4">
@@ -423,7 +423,7 @@
       <td>[60]</td>
       <td><code>PN_LOCAL_ESC</code></td>
       <td>::=</td>
-      <td>'<code class="grammar-literal">\</code>' <code class="grammar-paren">(</code>'<code class="grammar-literal">_</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">~</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">.</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">-</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">!</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">$</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">&amp;</code>' <code class="grammar-alt">|</code> "<code class="grammar-literal">&apos;</code>" <code class="grammar-alt">|</code> '<code class="grammar-literal">(</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">)</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">*</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">+</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">,</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">;</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">=</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">/</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">?</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">#</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">@</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">%</code>'<code class="grammar-paren">)</code></td>
+      <td>'<code class="grammar-literal">\</code>' <code class="grammar-paren">(</code>'<code class="grammar-literal">_</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">~</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">.</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">-</code>' <code class="grammar-alt">|</code> "<code class="grammar-literal">!</code>" <code class="grammar-alt">|</code> '<code class="grammar-literal">$</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">&amp;</code>' <code class="grammar-alt">|</code> "<code class="grammar-literal">&apos;</code>" <code class="grammar-alt">|</code> '<code class="grammar-literal">(</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">)</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">*</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">+</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">,</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">;</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">=</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">/</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">?</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">#</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">@</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">%</code>'<code class="grammar-paren">)</code></td>
     </tr>
   </tbody>
 </table>

--- a/spec/trig-bnf.html
+++ b/spec/trig-bnf.html
@@ -1,4 +1,4 @@
-<!-- Generated with ebnf version 2.3.4. See https://github.com/dryruby/ebnf. -->
+<!-- Generated with ebnf version 2.5.0. See https://github.com/dryruby/ebnf. -->
 <table class="grammar">
   <tbody id="grammar-productions" class="ebnf">
     <tr id="grammar-production-trigDoc">
@@ -17,7 +17,7 @@
       <td>[3]</td>
       <td><code>triplesOrGraph</code></td>
       <td>::=</td>
-      <td><code class="grammar-paren">(</code><a href="#grammar-production-labelOrSubject">labelOrSubject</a> <code class="grammar-paren">(</code><a href="#grammar-production-wrappedGraph">wrappedGraph</a> <code class="grammar-alt">|</code> <code class="grammar-paren">(</code><a href="#grammar-production-predicateObjectList">predicateObjectList</a> '<code class="grammar-literal">.</code>'<code class="grammar-paren">)</code><code class="grammar-paren">)</code><code class="grammar-paren">)</code> <code class="grammar-alt">|</code> <code class="grammar-paren">(</code><a href="#grammar-production-quotedTriple">quotedTriple</a> <a href="#grammar-production-predicateObjectList">predicateObjectList</a> '<code class="grammar-literal">.</code>'<code class="grammar-paren">)</code></td>
+      <td><code class="grammar-paren">(</code><a href="#grammar-production-labelOrSubject">labelOrSubject</a> <code class="grammar-paren">(</code><a href="#grammar-production-wrappedGraph">wrappedGraph</a> <code class="grammar-alt">|</code> <code class="grammar-paren">(</code><a href="#grammar-production-predicateObjectList">predicateObjectList</a> '<code class="grammar-literal">.</code>'<code class="grammar-paren">)</code><code class="grammar-paren">)</code><code class="grammar-paren">)</code> <code class="grammar-alt">|</code> <code class="grammar-paren">(</code><a href="#grammar-production-reifiedTriple">reifiedTriple</a> <a href="#grammar-production-predicateObjectList">predicateObjectList</a><code class="grammar-opt">?</code> '<code class="grammar-literal">.</code>'<code class="grammar-paren">)</code></td>
     </tr>
     <tr id="grammar-production-triples2">
       <td>[4]</td>
@@ -77,7 +77,7 @@
       <td>[13]</td>
       <td><code>triples</code></td>
       <td>::=</td>
-      <td><code class="grammar-paren">(</code><a href="#grammar-production-subject">subject</a> <a href="#grammar-production-predicateObjectList">predicateObjectList</a><code class="grammar-paren">)</code> <code class="grammar-alt">|</code> <code class="grammar-paren">(</code><a href="#grammar-production-blankNodePropertyList">blankNodePropertyList</a> <a href="#grammar-production-predicateObjectList">predicateObjectList</a><code class="grammar-opt">?</code><code class="grammar-paren">)</code></td>
+      <td><code class="grammar-paren">(</code><a href="#grammar-production-subject">subject</a> <a href="#grammar-production-predicateObjectList">predicateObjectList</a><code class="grammar-paren">)</code> <code class="grammar-alt">|</code> <code class="grammar-paren">(</code><a href="#grammar-production-blankNodePropertyList">blankNodePropertyList</a> <a href="#grammar-production-predicateObjectList">predicateObjectList</a><code class="grammar-opt">?</code><code class="grammar-paren">)</code> <code class="grammar-alt">|</code> <code class="grammar-paren">(</code><a href="#grammar-production-reifiedTriple">reifiedTriple</a> <a href="#grammar-production-predicateObjectList">predicateObjectList</a><code class="grammar-opt">?</code><code class="grammar-paren">)</code></td>
     </tr>
     <tr id="grammar-production-predicateObjectList">
       <td>[14]</td>
@@ -89,7 +89,7 @@
       <td>[15]</td>
       <td><code>objectList</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-object">object</a> <a href="#grammar-production-annotation">annotation</a><code class="grammar-opt">?</code> <code class="grammar-paren">(</code>'<code class="grammar-literal">,</code>' <a href="#grammar-production-object">object</a> <a href="#grammar-production-annotation">annotation</a><code class="grammar-opt">?</code><code class="grammar-paren">)</code><code class="grammar-star">*</code></td>
+      <td><a href="#grammar-production-object">object</a> <a href="#grammar-production-annotation">annotation</a> <code class="grammar-paren">(</code>'<code class="grammar-literal">,</code>' <a href="#grammar-production-object">object</a> <a href="#grammar-production-annotation">annotation</a><code class="grammar-paren">)</code><code class="grammar-star">*</code></td>
     </tr>
     <tr id="grammar-production-verb">
       <td>[16]</td>
@@ -101,7 +101,7 @@
       <td>[17]</td>
       <td><code>subject</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-iri">iri</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BlankNode">BlankNode</a> <code class="grammar-alt">|</code> <a href="#grammar-production-collection">collection</a> <code class="grammar-alt">|</code> <a href="#grammar-production-reification">reification</a></td>
+      <td><a href="#grammar-production-iri">iri</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BlankNode">BlankNode</a> <code class="grammar-alt">|</code> <a href="#grammar-production-collection">collection</a></td>
     </tr>
     <tr id="grammar-production-predicate">
       <td>[18]</td>
@@ -113,7 +113,7 @@
       <td>[19]</td>
       <td><code>object</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-iri">iri</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BlankNode">BlankNode</a> <code class="grammar-alt">|</code> <a href="#grammar-production-collection">collection</a> <code class="grammar-alt">|</code> <a href="#grammar-production-blankNodePropertyList">blankNodePropertyList</a> <code class="grammar-alt">|</code> <a href="#grammar-production-literal">literal</a> <code class="grammar-alt">|</code> <a href="#grammar-production-tripleTerm">tripleTerm</a> <code class="grammar-alt">|</code> <a href="#grammar-production-reification">reification</a></td>
+      <td><a href="#grammar-production-iri">iri</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BlankNode">BlankNode</a> <code class="grammar-alt">|</code> <a href="#grammar-production-collection">collection</a> <code class="grammar-alt">|</code> <a href="#grammar-production-blankNodePropertyList">blankNodePropertyList</a> <code class="grammar-alt">|</code> <a href="#grammar-production-literal">literal</a> <code class="grammar-alt">|</code> <a href="#grammar-production-tripleTerm">tripleTerm</a> <code class="grammar-alt">|</code> <a href="#grammar-production-reifiedTriple">reifiedTriple</a></td>
     </tr>
     <tr id="grammar-production-literal">
       <td>[20]</td>
@@ -175,29 +175,47 @@
       <td>::=</td>
       <td><a href="#grammar-production-BLANK_NODE_LABEL">BLANK_NODE_LABEL</a> <code class="grammar-alt">|</code> <a href="#grammar-production-ANON">ANON</a></td>
     </tr>
-    <tr id="grammar-production-reification">
+    <tr id="grammar-production-reifier">
       <td>[30]</td>
-      <td><code>reification</code></td>
+      <td><code>reifier</code></td>
       <td>::=</td>
-      <td>'<code class="grammar-literal">&lt;&lt;</code>' <code class="grammar-paren">(</code><code class="grammar-paren">(</code><a href="#grammar-production-iri">iri</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BlankNode">BlankNode</a><code class="grammar-paren">)</code> '<code class="grammar-literal">|</code>'<code class="grammar-paren">)</code><code class="grammar-opt">?</code> <a href="#grammar-production-subject">subject</a> <a href="#grammar-production-predicate">predicate</a> <a href="#grammar-production-object">object</a> '<code class="grammar-literal">&gt;&gt;</code>'</td>
+      <td>'<code class="grammar-literal">~</code>' <code class="grammar-paren">(</code><a href="#grammar-production-iri">iri</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BlankNode">BlankNode</a><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
+    </tr>
+    <tr id="grammar-production-reifiedTriple">
+      <td>[31]</td>
+      <td><code>reifiedTriple</code></td>
+      <td>::=</td>
+      <td>'<code class="grammar-literal">&lt;&lt;</code>' <code class="grammar-paren">(</code><a href="#grammar-production-subject">subject</a> <code class="grammar-alt">|</code> <a href="#grammar-production-reifiedTriple">reifiedTriple</a><code class="grammar-paren">)</code> <a href="#grammar-production-verb">verb</a> <a href="#grammar-production-object">object</a> <a href="#grammar-production-reifier">reifier</a><code class="grammar-opt">?</code> '<code class="grammar-literal">&gt;&gt;</code>'</td>
     </tr>
     <tr id="grammar-production-tripleTerm">
-      <td>[31]</td>
-     <td><code>tripleTerm</code></td>
+      <td>[32]</td>
+      <td><code>tripleTerm</code></td>
       <td>::=</td>
-      <td>'<code class="grammar-literal">&lt;&lt;(</code>' <a href="#grammar-production-subject">subject</a> <a href="#grammar-production-predicate">predicate</a> <a href="#grammar-production-ttObject">ttObject</a> '<code class="grammar-literal">)&gt;&gt;</code>'</td>
+      <td>'<code class="grammar-literal">&lt;&lt;(</code>' <a href="#grammar-production-ttSubject">ttSubject</a> <a href="#grammar-production-verb">verb</a> <a href="#grammar-production-ttObject">ttObject</a> '<code class="grammar-literal">)&gt;&gt;</code>'</td>
+    </tr>
+    <tr id="grammar-production-ttSubject">
+      <td>[33]</td>
+      <td><code>ttSubject</code></td>
+      <td>::=</td>
+      <td><a href="#grammar-production-iri">iri</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BlankNode">BlankNode</a></td>
     </tr>
     <tr id="grammar-production-ttObject">
-      <td>[32]</td>
+      <td>[34]</td>
       <td><code>ttObject</code></td>
       <td>::=</td>
       <td><a href="#grammar-production-iri">iri</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BlankNode">BlankNode</a> <code class="grammar-alt">|</code> <a href="#grammar-production-literal">literal</a> <code class="grammar-alt">|</code> <a href="#grammar-production-tripleTerm">tripleTerm</a></td>
     </tr>
     <tr id="grammar-production-annotation">
-      <td>[33]</td>
+      <td>[35]</td>
       <td><code>annotation</code></td>
       <td>::=</td>
-      <td>'<code class="grammar-literal">{|</code>' <code class="grammar-paren">(</code><code class="grammar-paren">(</code><a href="#grammar-production-iri">iri</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BlankNode">BlankNode</a><code class="grammar-paren">)</code> '<code class="grammar-literal">|</code>'<code class="grammar-paren">)</code><code class="grammar-opt">?</code> <a href="#grammar-production-predicateObjectList">predicateObjectList</a> '<code class="grammar-literal">|}</code>'</td>
+      <td><code class="grammar-paren">(</code><a href="#grammar-production-reifier">reifier</a> <code class="grammar-alt">|</code> <a href="#grammar-production-annotationBlock">annotationBlock</a><code class="grammar-paren">)</code><code class="grammar-star">*</code></td>
+    </tr>
+    <tr id="grammar-production-annotationBlock">
+      <td>[36]</td>
+      <td><code>annotationBlock</code></td>
+      <td>::=</td>
+      <td>'<code class="grammar-literal">{|</code>' <a href="#grammar-production-predicateObjectList">predicateObjectList</a> '<code class="grammar-literal">|}</code>'</td>
     </tr>
     <tr id="grammar-declaration-terminals">
       <td colspan="4">
@@ -205,109 +223,110 @@
       </td>
     </tr>
     <tr id="grammar-production-IRIREF">
-      <td>[35]</td>
+      <td>[38]</td>
       <td><code>IRIREF</code></td>
       <td>::=</td>
-      <td>'<code class="grammar-literal">&lt;</code>' <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">^</code><code class="grammar-char-escape"><abbr title="null">#x00</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">&lt;&gt;&quot;{}|^`\</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code class="grammar-paren">)</code><code class="grammar-star">*</code> '<code class="grammar-literal">&gt;</code>'</td>
+      <td>'<code class="grammar-literal">&lt;</code>' <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">^</code><code class="grammar-char-escape"><abbr title="null">#x00</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">&lt;&gt;&quot;{}|^`\</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code class="grammar-paren">)</code><code class="grammar-star">*</code> '<code class="grammar-literal">&gt;</code>'
+        <br/><span class="grammar_comment">/* #x00=NULL #x01-#x1F=control codes #x20=space */</span></td>
     </tr>
     <tr id="grammar-production-PNAME_NS">
-      <td>[36]</td>
+      <td>[39]</td>
       <td><code>PNAME_NS</code></td>
       <td>::=</td>
       <td><a href="#grammar-production-PN_PREFIX">PN_PREFIX</a><code class="grammar-opt">?</code> '<code class="grammar-literal">:</code>'</td>
     </tr>
     <tr id="grammar-production-PNAME_LN">
-      <td>[37]</td>
+      <td>[40]</td>
       <td><code>PNAME_LN</code></td>
       <td>::=</td>
       <td><a href="#grammar-production-PNAME_NS">PNAME_NS</a> <a href="#grammar-production-PN_LOCAL">PN_LOCAL</a></td>
     </tr>
     <tr id="grammar-production-BLANK_NODE_LABEL">
-      <td>[38]</td>
+      <td>[41]</td>
       <td><code>BLANK_NODE_LABEL</code></td>
       <td>::=</td>
       <td>'<code class="grammar-literal">_:</code>' <code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-paren">)</code> <code class="grammar-paren">(</code><code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS">PN_CHARS</a> <code class="grammar-alt">|</code> '<code class="grammar-literal">.</code>'<code class="grammar-paren">)</code><code class="grammar-star">*</code> <a href="#grammar-production-PN_CHARS">PN_CHARS</a><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
     </tr>
     <tr id="grammar-production-LANG_DIR">
-      <td>[39]</td>
+      <td>[42]</td>
       <td><code>LANG_DIR</code></td>
       <td>::=</td>
       <td>'<code class="grammar-literal">@</code>' <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code> <code class="grammar-paren">(</code>'<code class="grammar-literal">-</code>' <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z0-9</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code><code class="grammar-paren">)</code><code class="grammar-star">*</code> <code class="grammar-paren">(</code>'<code class="grammar-literal">--</code>' <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
     </tr>
     <tr id="grammar-production-INTEGER">
-      <td>[40]</td>
+      <td>[43]</td>
       <td><code>INTEGER</code></td>
       <td>::=</td>
       <td><code class="grammar-brac">[</code><code class="grammar-literal">+-</code><code class="grammar-brac">]</code><code class="grammar-opt">?</code> <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code></td>
     </tr>
     <tr id="grammar-production-DECIMAL">
-      <td>[41]</td>
+      <td>[44]</td>
       <td><code>DECIMAL</code></td>
       <td>::=</td>
       <td><code class="grammar-brac">[</code><code class="grammar-literal">+-</code><code class="grammar-brac">]</code><code class="grammar-opt">?</code> <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-star">*</code> '<code class="grammar-literal">.</code>' <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code><code class="grammar-paren">)</code></td>
     </tr>
     <tr id="grammar-production-DOUBLE">
-      <td>[42]</td>
+      <td>[45]</td>
       <td><code>DOUBLE</code></td>
       <td>::=</td>
       <td><code class="grammar-brac">[</code><code class="grammar-literal">+-</code><code class="grammar-brac">]</code><code class="grammar-opt">?</code> <code class="grammar-paren">(</code><code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code> '<code class="grammar-literal">.</code>' <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-star">*</code> <a href="#grammar-production-EXPONENT">EXPONENT</a><code class="grammar-paren">)</code> <code class="grammar-alt">|</code> <code class="grammar-paren">(</code>'<code class="grammar-literal">.</code>' <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code> <a href="#grammar-production-EXPONENT">EXPONENT</a><code class="grammar-paren">)</code> <code class="grammar-alt">|</code> <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code> <a href="#grammar-production-EXPONENT">EXPONENT</a><code class="grammar-paren">)</code><code class="grammar-paren">)</code></td>
     </tr>
     <tr id="grammar-production-EXPONENT">
-      <td>[43]</td>
+      <td>[46]</td>
       <td><code>EXPONENT</code></td>
       <td>::=</td>
       <td><code class="grammar-brac">[</code><code class="grammar-literal">eE</code><code class="grammar-brac">]</code> <code class="grammar-brac">[</code><code class="grammar-literal">+-</code><code class="grammar-brac">]</code><code class="grammar-opt">?</code> <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code></td>
     </tr>
     <tr id="grammar-production-STRING_LITERAL_QUOTE">
-      <td>[44]</td>
+      <td>[47]</td>
       <td><code>STRING_LITERAL_QUOTE</code></td>
       <td>::=</td>
       <td>'<code class="grammar-literal">&quot;</code>' <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">^</code><code class="grammar-char-escape"><abbr title="dquote">#x22</abbr></code><code class="grammar-char-escape"><abbr title="backslash">#x5C</abbr></code><code class="grammar-char-escape"><abbr title="new line">#x0A</abbr></code><code class="grammar-char-escape"><abbr title="carriage return">#x0D</abbr></code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-ECHAR">ECHAR</a> <code class="grammar-alt">|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code class="grammar-paren">)</code><code class="grammar-star">*</code> '<code class="grammar-literal">&quot;</code>'</td>
     </tr>
     <tr id="grammar-production-STRING_LITERAL_SINGLE_QUOTE">
-      <td>[45]</td>
+      <td>[48]</td>
       <td><code>STRING_LITERAL_SINGLE_QUOTE</code></td>
       <td>::=</td>
       <td>"<code class="grammar-literal">&apos;</code>" <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">^</code><code class="grammar-char-escape"><abbr title="apos">#x27</abbr></code><code class="grammar-char-escape"><abbr title="backslash">#x5C</abbr></code><code class="grammar-char-escape"><abbr title="new line">#x0A</abbr></code><code class="grammar-char-escape"><abbr title="carriage return">#x0D</abbr></code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-ECHAR">ECHAR</a> <code class="grammar-alt">|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code class="grammar-paren">)</code><code class="grammar-star">*</code> "<code class="grammar-literal">&apos;</code>"</td>
     </tr>
     <tr id="grammar-production-STRING_LITERAL_LONG_SINGLE_QUOTE">
-      <td>[46]</td>
+      <td>[49]</td>
       <td><code>STRING_LITERAL_LONG_SINGLE_QUOTE</code></td>
       <td>::=</td>
       <td>"<code class="grammar-literal">&apos;&apos;&apos;</code>" <code class="grammar-paren">(</code><code class="grammar-paren">(</code>"<code class="grammar-literal">&apos;</code>" <code class="grammar-alt">|</code> "<code class="grammar-literal">&apos;&apos;</code>"<code class="grammar-paren">)</code><code class="grammar-opt">?</code> <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">^&apos;\</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-ECHAR">ECHAR</a> <code class="grammar-alt">|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code class="grammar-paren">)</code><code class="grammar-paren">)</code><code class="grammar-star">*</code> "<code class="grammar-literal">&apos;&apos;&apos;</code>"</td>
     </tr>
     <tr id="grammar-production-STRING_LITERAL_LONG_QUOTE">
-      <td>[47]</td>
+      <td>[50]</td>
       <td><code>STRING_LITERAL_LONG_QUOTE</code></td>
       <td>::=</td>
       <td>'<code class="grammar-literal">&quot;&quot;&quot;</code>' <code class="grammar-paren">(</code><code class="grammar-paren">(</code>'<code class="grammar-literal">&quot;</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">&quot;&quot;</code>'<code class="grammar-paren">)</code><code class="grammar-opt">?</code> <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">^&quot;\</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-ECHAR">ECHAR</a> <code class="grammar-alt">|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code class="grammar-paren">)</code><code class="grammar-paren">)</code><code class="grammar-star">*</code> '<code class="grammar-literal">&quot;&quot;&quot;</code>'</td>
     </tr>
     <tr id="grammar-production-UCHAR">
-      <td>[48]</td>
+      <td>[51]</td>
       <td><code>UCHAR</code></td>
       <td>::=</td>
       <td><code class="grammar-paren">(</code>'<code class="grammar-literal">\u</code>' <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a><code class="grammar-paren">)</code> <code class="grammar-alt">|</code> <code class="grammar-paren">(</code>'<code class="grammar-literal">\U</code>' <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a><code class="grammar-paren">)</code></td>
     </tr>
     <tr id="grammar-production-ECHAR">
-      <td>[49]</td>
+      <td>[52]</td>
       <td><code>ECHAR</code></td>
       <td>::=</td>
       <td>'<code class="grammar-literal">\</code>' <code class="grammar-brac">[</code><code class="grammar-literal">tbnrf\&quot;&apos;</code><code class="grammar-brac">]</code></td>
     </tr>
     <tr id="grammar-production-WS">
-      <td>[50]</td>
+      <td>[53]</td>
       <td><code>WS</code></td>
       <td>::=</td>
       <td><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code> <code class="grammar-alt">|</code> <code class="grammar-char-escape"><abbr title="horizontal tab">#x09</abbr></code> <code class="grammar-alt">|</code> <code class="grammar-char-escape"><abbr title="carriage return">#x0D</abbr></code> <code class="grammar-alt">|</code> <code class="grammar-char-escape"><abbr title="new line">#x0A</abbr></code></td>
     </tr>
     <tr id="grammar-production-ANON">
-      <td>[51]</td>
+      <td>[54]</td>
       <td><code>ANON</code></td>
       <td>::=</td>
       <td>'<code class="grammar-literal">[</code>' <a href="#grammar-production-WS">WS</a><code class="grammar-star">*</code> '<code class="grammar-literal">]</code>'</td>
     </tr>
     <tr id="grammar-production-PN_CHARS_BASE">
-      <td>[52]</td>
+      <td>[55]</td>
       <td><code>PN_CHARS_BASE</code></td>
       <td>::=</td>
       <td><code class="grammar-brac">[</code><code class="grammar-literal">A-Z</code><code class="grammar-brac">]</code></td>
@@ -378,49 +397,49 @@
       <td><code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode U+10000">#x00010000</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode U+EFFFF">#x000EFFFF</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr id="grammar-production-PN_CHARS_U">
-      <td>[53]</td>
+      <td>[56]</td>
       <td><code>PN_CHARS_U</code></td>
       <td>::=</td>
       <td><a href="#grammar-production-PN_CHARS_BASE">PN_CHARS_BASE</a> <code class="grammar-alt">|</code> '<code class="grammar-literal">_</code>'</td>
     </tr>
     <tr id="grammar-production-PN_CHARS">
-      <td>[54]</td>
+      <td>[57]</td>
       <td><code>PN_CHARS</code></td>
       <td>::=</td>
       <td><a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code class="grammar-alt">|</code> '<code class="grammar-literal">-</code>' <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <code class="grammar-char-escape"><abbr title="unicode U+00B7">#xB7</abbr></code> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode U+0300">#x0300</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode U+036F">#x036F</abbr></code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode U+203F">#x203F</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode U+2040">#x2040</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr id="grammar-production-PN_PREFIX">
-      <td>[55]</td>
+      <td>[58]</td>
       <td><code>PN_PREFIX</code></td>
       <td>::=</td>
       <td><a href="#grammar-production-PN_CHARS_BASE">PN_CHARS_BASE</a> <code class="grammar-paren">(</code><code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS">PN_CHARS</a> <code class="grammar-alt">|</code> '<code class="grammar-literal">.</code>'<code class="grammar-paren">)</code><code class="grammar-star">*</code> <a href="#grammar-production-PN_CHARS">PN_CHARS</a><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
     </tr>
     <tr id="grammar-production-PN_LOCAL">
-      <td>[56]</td>
+      <td>[59]</td>
       <td><code>PN_LOCAL</code></td>
       <td>::=</td>
       <td><code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code class="grammar-alt">|</code> '<code class="grammar-literal">:</code>' <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-PLX">PLX</a><code class="grammar-paren">)</code> <code class="grammar-paren">(</code><code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS">PN_CHARS</a> <code class="grammar-alt">|</code> '<code class="grammar-literal">.</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">:</code>' <code class="grammar-alt">|</code> <a href="#grammar-production-PLX">PLX</a><code class="grammar-paren">)</code><code class="grammar-star">*</code> <code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS">PN_CHARS</a> <code class="grammar-alt">|</code> '<code class="grammar-literal">:</code>' <code class="grammar-alt">|</code> <a href="#grammar-production-PLX">PLX</a><code class="grammar-paren">)</code><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
     </tr>
     <tr id="grammar-production-PLX">
-      <td>[57]</td>
+      <td>[60]</td>
       <td><code>PLX</code></td>
       <td>::=</td>
       <td><a href="#grammar-production-PERCENT">PERCENT</a> <code class="grammar-alt">|</code> <a href="#grammar-production-PN_LOCAL_ESC">PN_LOCAL_ESC</a></td>
     </tr>
     <tr id="grammar-production-PERCENT">
-      <td>[58]</td>
+      <td>[61]</td>
       <td><code>PERCENT</code></td>
       <td>::=</td>
       <td>'<code class="grammar-literal">%</code>' <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a></td>
     </tr>
     <tr id="grammar-production-HEX">
-      <td>[59]</td>
+      <td>[62]</td>
       <td><code>HEX</code></td>
       <td>::=</td>
       <td><code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">A-F</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">a-f</code><code class="grammar-brac">]</code></td>
     </tr>
     <tr id="grammar-production-PN_LOCAL_ESC">
-      <td>[60]</td>
+      <td>[63]</td>
       <td><code>PN_LOCAL_ESC</code></td>
       <td>::=</td>
       <td>'<code class="grammar-literal">\</code>' <code class="grammar-paren">(</code>'<code class="grammar-literal">_</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">~</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">.</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">-</code>' <code class="grammar-alt">|</code> "<code class="grammar-literal">!</code>" <code class="grammar-alt">|</code> '<code class="grammar-literal">$</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">&amp;</code>' <code class="grammar-alt">|</code> "<code class="grammar-literal">&apos;</code>" <code class="grammar-alt">|</code> '<code class="grammar-literal">(</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">)</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">*</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">+</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">,</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">;</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">=</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">/</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">?</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">#</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">@</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">%</code>'<code class="grammar-paren">)</code></td>

--- a/spec/trig.bnf
+++ b/spec/trig.bnf
@@ -19,9 +19,9 @@ triples               ::= subject predicateObjectList | blankNodePropertyList pr
 predicateObjectList   ::= verb objectList (';' (verb objectList)? )*
 objectList            ::= object annotation? ( ',' object annotation? )*
 verb                  ::= predicate | 'a'
-subject               ::= iri | BlankNode | collection | quotedTriple
+subject               ::= iri | BlankNode | collection | reification
 predicate             ::= iri
-object                ::= iri | BlankNode | collection | blankNodePropertyList | literal | quotedTriple
+object                ::= iri | BlankNode | collection | blankNodePropertyList | literal | tripleTerm | reification
 literal               ::= RDFLiteral | NumericLiteral | BooleanLiteral
 blankNodePropertyList ::= '[' predicateObjectList ']'
 collection            ::= '(' object* ')'
@@ -33,10 +33,10 @@ String                ::= STRING_LITERAL_QUOTE | STRING_LITERAL_SINGLE_QUOTE
 iri                   ::= IRIREF | PrefixedName
 PrefixedName          ::= PNAME_LN | PNAME_NS
 BlankNode             ::= BLANK_NODE_LABEL | ANON
-quotedTriple          ::= '<<' qtSubject predicate qtObject '>>'
-qtSubject             ::=	iri | BlankNode | quotedTriple
-qtObject              ::=	iri | BlankNode | literal | quotedTriple
-annotation            ::= '{|' predicateObjectList '|}'
+reification           ::= '<<' ((iri | BlankNode) '|' )? subject predicate object '>>'
+tripleTerm            ::= '<<(' subject predicate ttObject ')>>'
+ttObject              ::=	iri | BlankNode | literal | tripleTerm
+annotation            ::= '{|' ( (iri | BlankNode) '|' )? predicateObjectList '|}'
 
 @terminals
 

--- a/spec/trig.bnf
+++ b/spec/trig.bnf
@@ -4,7 +4,7 @@ block                 ::=   triplesOrGraph
                         | triples2
                         | "GRAPH" labelOrSubject wrappedGraph
 triplesOrGraph        ::= labelOrSubject ( wrappedGraph | predicateObjectList '.' )
-                        | quotedTriple predicateObjectList '.'
+                        | reifiedTriple predicateObjectList? '.'
 triples2              ::= blankNodePropertyList predicateObjectList? '.'
                         | collection predicateObjectList '.'
 wrappedGraph          ::= '{' triplesBlock? '}'
@@ -15,13 +15,15 @@ prefixID              ::= '@prefix' PNAME_NS IRIREF '.'
 base                  ::= '@base' IRIREF '.'
 sparqlPrefix          ::=	"PREFIX" PNAME_NS IRIREF
 sparqlBase            ::=	"BASE" IRIREF
-triples               ::= subject predicateObjectList | blankNodePropertyList predicateObjectList?
+triples               ::= subject predicateObjectList
+                        | blankNodePropertyList predicateObjectList?
+                        | reifiedTriple predicateObjectList?
 predicateObjectList   ::= verb objectList (';' (verb objectList)? )*
-objectList            ::= object annotation? ( ',' object annotation? )*
+objectList            ::= object annotation ( ',' object annotation )*
 verb                  ::= predicate | 'a'
-subject               ::= iri | BlankNode | collection | reification
+subject               ::= iri | BlankNode | collection
 predicate             ::= iri
-object                ::= iri | BlankNode | collection | blankNodePropertyList | literal | tripleTerm | reification
+object                ::= iri | BlankNode | collection | blankNodePropertyList | literal | tripleTerm | reifiedTriple
 literal               ::= RDFLiteral | NumericLiteral | BooleanLiteral
 blankNodePropertyList ::= '[' predicateObjectList ']'
 collection            ::= '(' object* ')'
@@ -33,10 +35,13 @@ String                ::= STRING_LITERAL_QUOTE | STRING_LITERAL_SINGLE_QUOTE
 iri                   ::= IRIREF | PrefixedName
 PrefixedName          ::= PNAME_LN | PNAME_NS
 BlankNode             ::= BLANK_NODE_LABEL | ANON
-reification           ::= '<<' ((iri | BlankNode) '|' )? subject predicate object '>>'
-tripleTerm            ::= '<<(' subject predicate ttObject ')>>'
+reifier               ::= '~' (iri | BlankNode)?
+reifiedTriple         ::= '<<' (subject | reifiedTriple) verb object reifier? '>>'
+tripleTerm            ::= '<<(' ttSubject verb ttObject ')>>'
+ttSubject             ::=	iri | BlankNode
 ttObject              ::=	iri | BlankNode | literal | tripleTerm
-annotation            ::= '{|' ( (iri | BlankNode) '|' )? predicateObjectList '|}'
+annotation            ::= (reifier | annotationBlock)*
+annotationBlock       ::= '{|' predicateObjectList '|}'
 
 @terminals
 


### PR DESCRIPTION
- Adds tripleTerm and reification.
- Changes annotation to allow an identifier.
- Depends on "reification" being defined in RDF Concepts.

See https://github.com/w3c/rdf-turtle/pull/51


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-trig/pull/33.html" title="Last updated on Sep 12, 2024, 7:25 PM UTC (5c9a951)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-trig/33/2a68ff3...5c9a951.html" title="Last updated on Sep 12, 2024, 7:25 PM UTC (5c9a951)">Diff</a>