### PR TITLE
Remove the NIL terminal, unused in the grammar.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1139,6 +1139,7 @@
     <li>Changes the `LANGTAG` terminal production to
       <a href="#grammar-production-LANG_DIR" class="type langDir"><code>LANG_DIR</code></a> to include
       an optional <a data-cite="RDF12-CONCEPTS#dfn-base-direction">base direction</a>.</li>
+    <li>Removed the `NIL` terminal production from the grammar, which was unused.</li>
   </ul>
 </section>
 

--- a/spec/trig-bnf.html
+++ b/spec/trig-bnf.html
@@ -294,26 +294,20 @@
       <td>::=</td>
       <td>'<code class="grammar-literal">\</code>' <code class="grammar-brac">[</code><code class="grammar-literal">tbnrf\&quot;&apos;</code><code class="grammar-brac">]</code></td>
     </tr>
-    <tr id="grammar-production-NIL">
-      <td>[50]</td>
-      <td><code>NIL</code></td>
-      <td>::=</td>
-      <td>'<code class="grammar-literal">(</code>' <a href="#grammar-production-WS">WS</a><code class="grammar-star">*</code> '<code class="grammar-literal">)</code>'</td>
-    </tr>
     <tr id="grammar-production-WS">
-      <td>[51]</td>
+      <td>[50]</td>
       <td><code>WS</code></td>
       <td>::=</td>
       <td><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code> <code class="grammar-alt">|</code> <code class="grammar-char-escape"><abbr title="horizontal tab">#x09</abbr></code> <code class="grammar-alt">|</code> <code class="grammar-char-escape"><abbr title="carriage return">#x0D</abbr></code> <code class="grammar-alt">|</code> <code class="grammar-char-escape"><abbr title="new line">#x0A</abbr></code></td>
     </tr>
     <tr id="grammar-production-ANON">
-      <td>[52]</td>
+      <td>[51]</td>
       <td><code>ANON</code></td>
       <td>::=</td>
       <td>'<code class="grammar-literal">[</code>' <a href="#grammar-production-WS">WS</a><code class="grammar-star">*</code> '<code class="grammar-literal">]</code>'</td>
     </tr>
     <tr id="grammar-production-PN_CHARS_BASE">
-      <td>[53]</td>
+      <td>[52]</td>
       <td><code>PN_CHARS_BASE</code></td>
       <td>::=</td>
       <td><code class="grammar-brac">[</code><code class="grammar-literal">A-Z</code><code class="grammar-brac">]</code></td>
@@ -384,49 +378,49 @@
       <td><code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode U+10000">#x00010000</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode U+EFFFF">#x000EFFFF</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr id="grammar-production-PN_CHARS_U">
-      <td>[54]</td>
+      <td>[53]</td>
       <td><code>PN_CHARS_U</code></td>
       <td>::=</td>
       <td><a href="#grammar-production-PN_CHARS_BASE">PN_CHARS_BASE</a> <code class="grammar-alt">|</code> '<code class="grammar-literal">_</code>'</td>
     </tr>
     <tr id="grammar-production-PN_CHARS">
-      <td>[55]</td>
+      <td>[54]</td>
       <td><code>PN_CHARS</code></td>
       <td>::=</td>
       <td><a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code class="grammar-alt">|</code> '<code class="grammar-literal">-</code>' <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <code class="grammar-char-escape"><abbr title="unicode U+00B7">#xB7</abbr></code> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode U+0300">#x0300</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode U+036F">#x036F</abbr></code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode U+203F">#x203F</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode U+2040">#x2040</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr id="grammar-production-PN_PREFIX">
-      <td>[56]</td>
+      <td>[55]</td>
       <td><code>PN_PREFIX</code></td>
       <td>::=</td>
       <td><a href="#grammar-production-PN_CHARS_BASE">PN_CHARS_BASE</a> <code class="grammar-paren">(</code><code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS">PN_CHARS</a> <code class="grammar-alt">|</code> '<code class="grammar-literal">.</code>'<code class="grammar-paren">)</code><code class="grammar-star">*</code> <a href="#grammar-production-PN_CHARS">PN_CHARS</a><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
     </tr>
     <tr id="grammar-production-PN_LOCAL">
-      <td>[57]</td>
+      <td>[56]</td>
       <td><code>PN_LOCAL</code></td>
       <td>::=</td>
       <td><code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code class="grammar-alt">|</code> '<code class="grammar-literal">:</code>' <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-PLX">PLX</a><code class="grammar-paren">)</code> <code class="grammar-paren">(</code><code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS">PN_CHARS</a> <code class="grammar-alt">|</code> '<code class="grammar-literal">.</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">:</code>' <code class="grammar-alt">|</code> <a href="#grammar-production-PLX">PLX</a><code class="grammar-paren">)</code><code class="grammar-star">*</code> <code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS">PN_CHARS</a> <code class="grammar-alt">|</code> '<code class="grammar-literal">:</code>' <code class="grammar-alt">|</code> <a href="#grammar-production-PLX">PLX</a><code class="grammar-paren">)</code><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
     </tr>
     <tr id="grammar-production-PLX">
-      <td>[58]</td>
+      <td>[57]</td>
       <td><code>PLX</code></td>
       <td>::=</td>
       <td><a href="#grammar-production-PERCENT">PERCENT</a> <code class="grammar-alt">|</code> <a href="#grammar-production-PN_LOCAL_ESC">PN_LOCAL_ESC</a></td>
     </tr>
     <tr id="grammar-production-PERCENT">
-      <td>[59]</td>
+      <td>[58]</td>
       <td><code>PERCENT</code></td>
       <td>::=</td>
       <td>'<code class="grammar-literal">%</code>' <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a></td>
     </tr>
     <tr id="grammar-production-HEX">
-      <td>[60]</td>
+      <td>[59]</td>
       <td><code>HEX</code></td>
       <td>::=</td>
       <td><code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">A-F</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">a-f</code><code class="grammar-brac">]</code></td>
     </tr>
     <tr id="grammar-production-PN_LOCAL_ESC">
-      <td>[61]</td>
+      <td>[60]</td>
       <td><code>PN_LOCAL_ESC</code></td>
       <td>::=</td>
       <td>'<code class="grammar-literal">\</code>' <code class="grammar-paren">(</code>'<code class="grammar-literal">_</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">~</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">.</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">-</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">!</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">$</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">&amp;</code>' <code class="grammar-alt">|</code> "<code class="grammar-literal">&apos;</code>" <code class="grammar-alt">|</code> '<code class="grammar-literal">(</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">)</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">*</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">+</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">,</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">;</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">=</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">/</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">?</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">#</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">@</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">%</code>'<code class="grammar-paren">)</code></td>

--- a/spec/trig.bnf
+++ b/spec/trig.bnf
@@ -55,7 +55,6 @@ STRING_LITERAL_LONG_SINGLE_QUOTE  ::= "'''" ( ( "'" | "''" )? ( [^'\] | ECHAR | 
 STRING_LITERAL_LONG_QUOTE         ::= '"""' ( ( '"' | '""' )? ( [^"\] | ECHAR | UCHAR ) )* '"""'
 UCHAR             ::= ( '\u' HEX HEX HEX HEX ) | ( '\U' HEX HEX HEX HEX HEX HEX HEX HEX )
 ECHAR             ::= ('\' [tbnrf\"'])
-NIL               ::= '(' WS* ')'
 WS                ::= #x20 | #x9 | #xD | #xA /* #x20=space #x9=character tabulation #xD=carriage return #xA=new line */
 ANON              ::= '[' WS* ']'
 PN_CHARS_BASE     ::= ([A-Z]


### PR DESCRIPTION
See w3c/rdf-turtle#58.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-trig/pull/35.html" title="Last updated on Jun 5, 2024, 4:55 PM UTC (99cdf71)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-trig/35/aee9bf7...99cdf71.html" title="Last updated on Jun 5, 2024, 4:55 PM UTC (99cdf71)">Diff</a>