### PR TITLE
Adds a link to the text version of the BNF file.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -642,6 +642,7 @@
     </div>
 
     <div data-include="trig-bnf.html"></div>
+    <p>A text version of this grammar is available <a href="trig.bnf">here</a>.</p>
 
   </section>
   <section>


### PR DESCRIPTION
This makes it more convenient for people to access the EBNF without having to scrape the HTML.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-trig/pull/37.html" title="Last updated on Sep 18, 2024, 7:37 PM UTC (78d9d92)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-trig/37/7294f21...78d9d92.html" title="Last updated on Sep 18, 2024, 7:37 PM UTC (78d9d92)">Diff</a>