### PR TITLE
reorganize content about backward compatibility

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -173,14 +173,7 @@
 
   <p>This specification extends the original TriG syntax, as defined in [[[TRIG]]] [[TRIG]],
   to support the new features introduced by [[[RDF12-CONCEPTS]]] [[RDF12-CONCEPTS]].
-  This extension is fully backward compatible:
-  any document complying with the old version complies with the new version, and parses to the same graph.
-  Furthermore, any document complying with the new version and containing only RDF 1.1 features is also compliant with the older version
-  (with the exception of the `VERSION` directive; see <a href="#sec-version"></a>).
-  Finally, none of the new syntactic constructs are valid in the old syntax.
-  This means that any TriG document using RDF 1.2 features does not
-  comply with the previous version of this specification and cannot be
-  interpreted as a different graph under it.</p>
+  This extension is fully backward compatible.</p>
 </section>
 
 <section id="sec-trig-intro" class="informative">
@@ -1444,6 +1437,19 @@
 
  <p>This section describes the main differences
    from the RDF 1.1 Recommendation.</p>
+
+  <p>This specification extends the original TriG syntax, as defined in [[[TRIG]]] [[TRIG]],
+  to support the new features introduced by [[[RDF12-CONCEPTS]]] [[RDF12-CONCEPTS]].
+  This extension is fully backward compatible:
+  any document complying with the old version complies with the new version, and parses to the same graph.
+  Furthermore, any document complying with the new version and containing only RDF 1.1 features is also compliant with the older version
+  (with the exception of the `VERSION` directive; see <a href="#sec-version"></a>).
+  Finally, none of the new syntactic constructs are valid in the old syntax.
+  This means that any TriG document using RDF 1.2 features does not
+  comply with the previous version of this specification and cannot be
+  interpreted as a different graph under it.</p>
+
+  <p>More specifically, the following changes have been made:</p>
 
   <ul>
     <li>Syntax is aligned to the Turtle [[RDF12-TURTLE]] recommendation for <a data-cite="RDF12-CONCEPTS#dfn-rdf-term">RDF terms</a>.</li>


### PR DESCRIPTION
following the same rationale as [w3c/n-triples#105](https://github.com/w3c/rdf-n-triples/pull/105)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-trig/pull/66.html" title="Last updated on May 29, 2026, 12:12 PM UTC (5d45391)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-trig/66/c07d3a3...5d45391.html" title="Last updated on May 29, 2026, 12:12 PM UTC (5d45391)">Diff</a>